### PR TITLE
Cleanup and remove redundancies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 
 The backend server is built using:
 - Flask for the web framework to develop the REST API
-- TODO: Add relevant ML packages
+- ML/NLP libraries such as `numpy`, `pandas`, `pytorch`, `transformers` etc.
 
 ### Installation
 
@@ -50,11 +50,6 @@ This project uses [`venv` to manage packages](https://packaging.python.org/en/la
 
 Create a virtual environment:
 
-Windows:
-```bash
-py -m venv venv
-```
-MacOS:
 ```bash
 python -m venv venv
 ```
@@ -63,33 +58,23 @@ The second argument is the location to create the virtual environment. You can c
 to use it consistently for the other steps. e.g. `py -m venv .env` will create the virtual environment in a folder called `.env`.
 
 Activate the virtual environment:
-Windows:
+
 ```bash
+# Windows
 .\venv\Scripts\activate
-```
-Unix/MacOS:
-```bash
+
+# Unix/MacOS
 source venv/bin/activate
 ```
 
 Use the `requirements.txt` file to install the relevant packages. Anything regarding packages and their respective commands  should be done using the activated virtual environment.
 
-Windows:
-```bash
-py -m pip install -r requirements.txt
-```
-MacOS:
 ```bash
 python -m pip install -r requirements.txt
 ```
 
 **Note:** Every time you install new packages (not the initial setup), make sure to update the `requirements.txt` file:
 
-Windows:
-```bash
-py -m pip freeze > requirements.txt
-```
-MacOS:
 ```bash
 python -m pip freeze > requirements.txt
 ```
@@ -136,7 +121,7 @@ You can obviously also run the image using the Docker Desktop GUI if you prefer 
 There is a script to populate the Qdrant database with the relevant data. Once
 you have the Qdrant container running, you can run the script:
 ```bash
-py app/init_clauses.py
+python app/init_clauses.py
 ```
 
 #### Server
@@ -149,50 +134,25 @@ flask run --debug
 ### Testing
 
 The backend uses [pytest](https://docs.pytest.org) for testing. To run the tests:
-Windows:
-```bash
-py -m pytest
-```
-MacOS:
 ```bash
 python -m pytest
 ```
 To get a list of the functions tested rather than the dots use the verbose flag
-Windows:
 ```bash
-py -m pytest -v
-```
-MacOS:
-```bash
-py -m pytest -v
+python -m pytest -v
 ```
 
 To measure the code coverage of the tests:
-Windows:
-```bash
-py -m coverage run -m pytest
-```
-MacOS:
 ```bash
 python -m coverage run -m pytest
 ```
 
 This generates a `.coverage` file. When you have this you can view the report in the terminal:
-Windows:
-```bash
-py -m coverage report
-```
-MacOS:
 ```bash
 python -m coverage report
 ```
 
 You can also alternatively view the report data in HTML:
-Windows:
-```bash
-py -m coverage html
-```
-MacOS:
 ```bash
 python -m coverage html
 ```


### PR DESCRIPTION
Remove the Windows/MacOS duplication in README and just keeps the MacOS stuff for relevant steps.